### PR TITLE
docs: update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 All members of the project community must abide by the [SAP Open Source Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md).
 Only by respecting each other we can develop a productive, collaborative community.
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](.reuse/dep5).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](REUSE.toml).
 
 ## Engaging in Our Project
 


### PR DESCRIPTION
Fix two stale links in CONTRIBUTING.md:

- Replace local `CODE_OF_CONDUCT.md` reference with the canonical external URL to the Contributor Covenant v2.1
- Replace `.reuse/dep5` maintainer contact link with `REUSE.toml` (current REUSE format)

Part of a batch update applied across all `sap-cs-devops` repos.